### PR TITLE
Fix inverted image in sign in view

### DIFF
--- a/reverb-dark.user.css
+++ b/reverb-dark.user.css
@@ -37,6 +37,7 @@
   /* Revert some color inverts (mostly for images) */
   [style*="background"],
   .reverb-header img,
+  div.session-header,
   div.video-embed,
   div.payment-icon,
   div.lightbox-image-item__video-frame,


### PR DESCRIPTION
Fixes https://github.com/synthead/reverb-dark/issues/2!

Before:

![image](https://user-images.githubusercontent.com/820984/225607451-c5172d67-5874-41f4-8190-582be2d83c18.png)

After:

![image](https://user-images.githubusercontent.com/820984/225607537-12d0ea67-7008-4b43-bdc7-831b11d39349.png)
